### PR TITLE
Oreo front flash support for los 15.1

### DIFF
--- a/drivers/media/platform/msm/camera_v2/sensor/flash/Makefile
+++ b/drivers/media/platform/msm/camera_v2/sensor/flash/Makefile
@@ -3,4 +3,4 @@ ccflags-y += -Idrivers/media/platform/msm/camera_v2
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/common
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/sensor/io
 obj-$(CONFIG_MSMB_CAMERA) += msm_flash.o
-obj-$(CONFIG_MSMB_CAMERA_2017) += msm_flash_gpio.o
+obj-$(CONFIG_MSMB_CAMERA) += msm_flash_gpio.o

--- a/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash_gpio.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash_gpio.c
@@ -29,7 +29,7 @@ static struct v4l2_file_operations msm_flash_v4l2_subdev_fops;
 static DEFINE_MUTEX(flash_lock);
 
 static const struct of_device_id msm_flash_dt_match[] = {
-	{.compatible = "qcom,camera-led-flash", .data = NULL},
+	{.compatible = "qcom,camera-gpio-flash", .data = NULL},
 	{}
 };
 static int32_t msm_flash_init_gpio_pin_tbl(struct device_node *of_node,
@@ -669,7 +669,7 @@ MODULE_DEVICE_TABLE(of, msm_flash_dt_match);
 static struct platform_driver msm_flash_platform_driver = {
 	.probe = msm_flash_platform_probe,
 	.driver = {
-		.name = "qcom,camera-led-flash",
+		.name = "qcom,camera-gpio-flash",
 		.owner = THIS_MODULE,
 		.of_match_table = msm_flash_dt_match,
 	},

--- a/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash_gpio.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash_gpio.c
@@ -237,7 +237,7 @@ static int32_t msm_flash_low(
 		gpio_set_value(
 		power_info->gpio_conf->gpio_num_info->gpio_num[0],
 		GPIO_OUT_HIGH);
-		for (i = 0 ; i <= 14 ; i++) {
+		for (i = 0 ; i <= 9 ; i++) {
 			gpio_set_value(
 			power_info->gpio_conf->gpio_num_info->gpio_num[0],
 			GPIO_OUT_LOW);
@@ -277,7 +277,7 @@ static int32_t msm_flash_high(
 		gpio_set_value(
 		power_info->gpio_conf->gpio_num_info->gpio_num[0],
 		GPIO_OUT_HIGH);
-		for (i = 0 ; i <= 10 ; i++) {
+		for (i = 0 ; i <= 1 ; i++) {
 			gpio_set_value(
 			power_info->gpio_conf->gpio_num_info->gpio_num[0],
 			GPIO_OUT_LOW);


### PR DESCRIPTION
In theory should be compatible with 16 but need to test it on actual device. @JarlPenguin  review please and merge with current oreo branch in way you thing is correct